### PR TITLE
textareas don't respect rows property when autogrow is set to true

### DIFF
--- a/packages/svelte-materialify/src/components/Textarea/Textarea.svelte
+++ b/packages/svelte-materialify/src/components/Textarea/Textarea.svelte
@@ -63,7 +63,7 @@
   function onInput() {
     if (!validateOnBlur) checkRules();
     if (autogrow) {
-      textarea.style.height = 0;
+      textarea.style.height = 'auto';
       textarea.style.height = `${textarea.scrollHeight}px`;
     }
   }


### PR DESCRIPTION
Textareas don't respect the `rows` property when `autogrow` is set to true, as their height is set to `0` when the input changes. This bug doesn't occur when changing `0` to `'auto'`.