### PR TITLE
fix(checkbox): update groupUpdate method edge case when value = 0

### DIFF
--- a/packages/svelte-materialify/src/components/Checkbox/Checkbox.svelte
+++ b/packages/svelte-materialify/src/components/Checkbox/Checkbox.svelte
@@ -39,9 +39,9 @@
 
   id = id || `s-checkbox-${uid(5)}`;
 
-  const hasValidGroup = Array.isArray(group);
-  if (hasValidGroup && value != null) {
-    if (group.indexOf(value) >= 0) checked = true;
+  $: hasValidGroup = Array.isArray(group);
+  $: if (hasValidGroup && value != null) {
+    checked = group.indexOf(value) >= 0;
   }
 
   function groupUpdate() {

--- a/packages/svelte-materialify/src/components/Checkbox/Checkbox.svelte
+++ b/packages/svelte-materialify/src/components/Checkbox/Checkbox.svelte
@@ -40,12 +40,12 @@
   id = id || `s-checkbox-${uid(5)}`;
 
   const hasValidGroup = Array.isArray(group);
-  if (hasValidGroup && value) {
+  if (hasValidGroup && value != null) {
     if (group.indexOf(value) >= 0) checked = true;
   }
 
   function groupUpdate() {
-    if (hasValidGroup && value) {
+    if (hasValidGroup && value != null) {
       const i = group.indexOf(value);
       if (i < 0) {
         group.push(value);


### PR DESCRIPTION
## Problem description and solution
[group update feature](https://svelte-materialify.vercel.app/components/checkboxes/#groups) is not updating the group variable when checkbox value is zero:

`value` when set to `0` was evaluating to `false` inside the if statements on line 43 and 48. I believe the intended check is to see if the value is valid. I changed it to `value != null` and I got the same behavior as with the native checkbox components


## Example test case:
```svelte
<div class="ma-5">
	{#each [0,1,2,3] as i}
		<Checkbox color="secondary" bind:group={selected} value={i}>value={i}</Checkbox>
	{/each}
	<div>
		Selected: {JSON.stringify(selected)}
	</div>
</div>
```
Output before the fix:
![image](https://user-images.githubusercontent.com/8341386/97329948-ff515200-184d-11eb-913e-a03a71a24c13.png)

Output after the fix:
![image](https://user-images.githubusercontent.com/8341386/97331244-87842700-184f-11eb-8242-0f74570fd2a0.png)



## `yarn test` output:
![image](https://user-images.githubusercontent.com/8341386/97327755-a97baa80-184b-11eb-97b3-9d081d8c6d34.png)
