### PR TITLE
fix(styles): update aria-disabled selector

### DIFF
--- a/packages/svelte-materialify/src/styles/generic/_reset.scss
+++ b/packages/svelte-materialify/src/styles/generic/_reset.scss
@@ -278,6 +278,6 @@ svg:not([fill]) {
 }
 
 /* Specify the unstyled cursor of disabled, not-editable, or otherwise inoperable elements */
-[aria-disabled] {
+[aria-disabled=true] {
   cursor: default;
 }


### PR DESCRIPTION
A little fix to keep the pointer cursor when `aria-disabled` is `false`. To reproduce pass `false` to the `disabled` prop of a `Button`.