### PR TITLE
feat(icon): make icon clickable

### DIFF
--- a/packages/api-generator/src/Icon.json
+++ b/packages/api-generator/src/Icon.json
@@ -128,7 +128,18 @@
   "components": [],
   "description": null,
   "keywords": [],
-  "events": [],
+  "events": [
+    {
+      "name": "click",
+      "parent": "i",
+      "modificators": [],
+      "locations": null,
+      "loc": null,
+      "visibility": "public",
+      "description": "",
+      "keywords": []
+    }
+  ],
   "slots": [
     {
       "name": "default",

--- a/packages/svelte-materialify/src/components/Icon/Icon.svelte
+++ b/packages/svelte-materialify/src/components/Icon/Icon.svelte
@@ -23,7 +23,8 @@
   class:disabled
   use:Style={{ 'icon-size': size, 'icon-rotate': `${rotate}deg` }}
   aria-disabled={disabled}
-  {style}>
+  {style}
+  on:click>
   {#if path}
     <svg
       xmlns="http://www.w3.org/2000/svg"

--- a/packages/svelte-materialify/src/styles/generic/_flex.scss
+++ b/packages/svelte-materialify/src/styles/generic/_flex.scss
@@ -249,3 +249,34 @@
     }
   }
 }
+
+.flex-grow-0 {
+  flex-grow: 0;
+}
+
+.flex-grow-1 {
+  flex-grow: 1;
+}
+
+.flex-shrink-0 {
+  flex-shrink: 0;
+}
+
+.flex-shrink-1 {
+  flex-shrink: 1;
+}
+
+@include create_breakpoints() using ($screen_size) {
+  .flex-#{$screen_size}-grow-0 {
+    flex-grow: 0;
+  }
+  .flex-#{$screen_size}-grow-1 {
+    flex-grow: 1;
+  }
+  .flex-#{$screen_size}-shrink-0 {
+    flex-shrink: 0;
+  }
+  .flex-#{$screen_size}-shrink-1 {
+    flex-shrink: 1;
+  }
+}


### PR DESCRIPTION
Forwarding the on:click on the ```<i>``` element so it can be listened on consumers of the Icon component.

Not sure if the API documentation is correct, not many examples of documenting events.
