### PR TITLE
fix(types): missing export of Menu

### DIFF
--- a/packages/svelte-materialify/@types/index.d.ts
+++ b/packages/svelte-materialify/@types/index.d.ts
@@ -26,6 +26,7 @@ export { default as ListGroup } from './ListGroup';
 export { default as ListItemGroup } from './ListItemGroup';
 export { default as ListItem } from './ListItem';
 export { default as MaterialApp } from './MaterialApp';
+export { default as Menu } from './Menu';
 export { default as NavigationDrawer } from './NavigationDrawer';
 export { default as Dialog } from './Dialog';
 export { default as Overlay } from './Overlay';


### PR DESCRIPTION
Thank you for such a great UI framework :tada:

You have `Menu.d.ts`, but it is not exported in `index.d.ts`.
I just added one line to `index.d.ts`.