### PR TITLE
fix(ItemGroup): make value an array if it's not an index

### DIFF
--- a/packages/svelte-materialify/src/components/ItemGroup/ItemGroup.svelte
+++ b/packages/svelte-materialify/src/components/ItemGroup/ItemGroup.svelte
@@ -33,7 +33,9 @@
         } else if (value.length < max) value = [...value, val];
       } else if (value === val) {
         if (!mandatory) value = null;
-      } else value = val;
+      } else if (typeof (val) === 'number') {
+        value = val;
+      } else value = [val];
     },
     register: (setValue) => {
       const u = valueStore.subscribe((val) => {


### PR DESCRIPTION
Hi, I've tried to fix #90 and have something that seems to work. Hopefully someone can use this to fix it properly.

This fixes multiple broken playgrounds and examples in the docs.

`value = [val]` fixes dropdowns [like](https://svelte-materialify.vercel.app/components/alerts/#playground) [these](https://svelte-materialify.vercel.app/components/buttons/#playground). Then I had to add `typeof (val) === 'number'` to stop [the first three of these ListItemGroups](https://svelte-materialify.vercel.app/components/list-item-groups/) from breaking.

Preview: https://svelte-materialify-git-fork-dincahill-fix-itemgroup.thecomputerm.vercel.app/components/alerts/#playground
Preview: https://svelte-materialify-git-fork-dincahill-fix-itemgroup.thecomputerm.vercel.app/components/list-item-groups/