### PR TITLE
docs(Breadcrumbs): use slot for divider in playground

### DIFF
--- a/packages/docs/src/playground/Breadcrumbs.svelte
+++ b/packages/docs/src/playground/Breadcrumbs.svelte
@@ -24,5 +24,9 @@
 </script>
 
 <Playground {controls} bind:values>
-  <Breadcrumbs large={values.large} {items} divider={values.divider[0]} />
+  <Breadcrumbs large={values.large} {items}>
+    <div slot="divider">
+      {values.divider[0]}
+    </div>
+  </Breadcrumbs>
 </Playground>


### PR DESCRIPTION
Fixes the divider dropdown [here](https://svelte-materialify.vercel.app/components/breadcrumbs/#playground).

Preview: https://svelte-materia-git-fork-dincahill-fix-breadcrumbs-pla-097a96.thecomputerm.vercel.app/components/breadcrumbs/#playground.