### PR TITLE
fix(clickOutside): set event propagation to capturing phase

### DIFF
--- a/packages/svelte-materialify/src/actions/ClickOutside/index.js
+++ b/packages/svelte-materialify/src/actions/ClickOutside/index.js
@@ -10,7 +10,7 @@ export default (node, _options = {}) => {
       node.dispatchEvent(new CustomEvent('clickOutside'));
     }
   }
-  document.addEventListener('click', detect, { passive: true });
+  document.addEventListener('click', detect, { passive: true, capture: true });
   return {
     destroy() {
       document.removeEventListener('click', detect);


### PR DESCRIPTION
Actually elements causing events with stopPropagation don't trigger function that detect click outside, because event propagation is bubbling by default and it stops at event target. 

By setting capture to true, event propagation will start from window and the function will be triggered correctly.

https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture