### PR TITLE
feat(MaterialApp): make full height

### DIFF
--- a/packages/docs/static/styles.css
+++ b/packages/docs/static/styles.css
@@ -4,6 +4,9 @@
 html {
   scroll-behavior: smooth;
 }
+#root {
+  height: 100%;
+}
 :target {
   scroll-margin-top: 64px;
 }

--- a/packages/svelte-materialify/src/components/MaterialApp/MaterialApp.scss
+++ b/packages/svelte-materialify/src/components/MaterialApp/MaterialApp.scss
@@ -1,0 +1,5 @@
+@import '../../styles/global';
+
+.s-app {
+  min-height: 100%;
+}

--- a/packages/svelte-materialify/src/components/MaterialApp/MaterialApp.svelte
+++ b/packages/svelte-materialify/src/components/MaterialApp/MaterialApp.svelte
@@ -2,8 +2,7 @@
   export let theme = 'light';
 </script>
 
-<style type="scss" global>
-  @import '../../styles/global';
+<style type="scss" src="./MaterialApp.scss" global>
 </style>
 
 <div class="s-app theme--{theme}">


### PR DESCRIPTION
Needs min-height to work for both: sites which don't cover the whole screen and sites with scroll.
(btw. there seems to be inconsistent browser behavior based on html/body height, please test more browsers)
chrome88 works