### PR TITLE
Update customActions.svelte Transition Container Update

### DIFF
--- a/packages/docs/src/examples/Card/customActions.svelte
+++ b/packages/docs/src/examples/Card/customActions.svelte
@@ -28,11 +28,13 @@
       </Button>
     </CardActions>
     {#if active}
-      <Divider />
-      <div transition:slide class="pl-4 pr-4 pt-2 pb-2">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita autem,
-        asperiores dolores, doloremque ea atque suscipit dolore, ut adipisci amet possimus
-        dicta at voluptas consequatur!
+      <div transition:slide>
+        <Divider />
+        <div class="pl-4 pr-4 pt-2 pb-2">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita autem,
+          asperiores dolores, doloremque ea atque suscipit dolore, ut adipisci amet possimus
+          dicta at voluptas consequatur!
+        </div>
       </div>
     {/if}
   </Card>


### PR DESCRIPTION
If using {#if} with child container that has padding, the padding/margin makes the transition jagged (padding instantly appears before transition can finish)

To correct this, {#if} should have a child container that does the transition. The grandchildren can have whatever padding/margin needed.

tl;dr
```
{#if}
    <div transition>
        <div paddings here>
            {content}
        </div>
    </div
{/if}
```
Edit:
Closes #127 