### PR TITLE
feat(Tab): forward click event

### DIFF
--- a/packages/svelte-materialify/src/components/Tabs/Tab.svelte
+++ b/packages/svelte-materialify/src/components/Tabs/Tab.svelte
@@ -47,6 +47,7 @@
   class:active
   use:Class={[active && activeClass]}
   on:click={selectTab}
+  on:click
   use:Ripple={ripple}>
   <slot />
 </button>


### PR DESCRIPTION
It would be very convenient (for my application at least) to be able to react on click events on Tabs, so I forwarded the event. While digging a bit in the API documentation(s), I had the feeling there is some inconsistency between the components regarding the available events. The ListItem component, for example, is forwarding the click event. It would be good IMHO to align these across the components as far as possible.  