### PR TITLE
feat(Slider): add precision prop to customize decimal places of slider value

### DIFF
--- a/packages/svelte-materialify/src/components/Slider/Slider.svelte
+++ b/packages/svelte-materialify/src/components/Slider/Slider.svelte
@@ -17,6 +17,7 @@
   export let connect = Array.isArray(value) ? true : 'lower';
   export let color = 'primary';
   export let step = null;
+  export let precision = 0;
   export let margin = null;
   export let limit = null;
   export let padding = null;
@@ -55,7 +56,7 @@
     noUiSlider.create(sliderElement, {
       cssPrefix: 's-slider__',
       format: {
-        to: (v) => Math.round(v),
+        to: (v) => v.toFixed(precision),
         from: (v) => Number(v),
       },
       start: value,


### PR DESCRIPTION
One potential problem remains the displayed value in the thumb. If too many decimal places are defined, the displayed value is exceeding the thumb "area". This is, however, already an issue with very large numbers (>=10000). Possible fixes: 
- Make the size of the thumb customizable
- Make the size of the thumb responsive to the value (no clue how that could be done easily)
- Prevent using the thumb when precision > 1 (not a very reliable workaround)

Should resolve #112 