### PR TITLE
feat(types): Enable types when importing from /src

### DIFF
--- a/packages/svelte-materialify/src/index.d.ts
+++ b/packages/svelte-materialify/src/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../@types/index';


### PR DESCRIPTION
Resolves #173

Previously, when using the 'Advanced Installation' method outlined
in docs, types would be unavailable. By providing an index.d.ts
file in /src, types become available whether importing from the
compiled package or importing from the package source.