### PR TITLE
fix show items after fetching

### DIFF
--- a/packages/svelte-materialify/src/components/Select/Select.svelte
+++ b/packages/svelte-materialify/src/components/Select/Select.svelte
@@ -42,7 +42,7 @@
         {solo}
         {dense}
         {disabled}
-        value={format(value)}
+        value={items ? format(value) : 'no items'}
         {placeholder}
         {hint}
         readonly>


### PR DESCRIPTION
after fetching the items is empty array. after test it update and array is full.
https://svelte.dev/repl/68079ea894674291b8766cadc087101e?version=3.35.0