### PR TITLE
fix: sliderUi library imported incorrectly for SPA and SSR #171

### DIFF
--- a/packages/svelte-materialify/src/components/Slider/Slider.svelte
+++ b/packages/svelte-materialify/src/components/Slider/Slider.svelte
@@ -96,7 +96,7 @@
   }
 
   afterUpdate(() => {
-    if (value !== localValue) slider.set(value, false);
+    if (slider && value !== localValue) slider.set(value, false);
   });
 </script>
 

--- a/packages/svelte-materialify/src/components/Slider/Slider.svelte
+++ b/packages/svelte-materialify/src/components/Slider/Slider.svelte
@@ -1,7 +1,3 @@
-<script context="module">
-  import noUiSlider from './nouislider.min';
-</script>
-
 <script>
   import Input from '../Input';
   import { onMount, afterUpdate, createEventDispatcher } from 'svelte';
@@ -51,7 +47,9 @@
     return thumb;
   }
 
-  onMount(() => {
+  onMount(async () => {
+    const { default: noUiSlider } = await import('./nouislider.min');
+    
     noUiSlider.cssClasses.tooltip = `tooltip ${thumbClass}`;
     noUiSlider.create(sliderElement, {
       cssPrefix: 's-slider__',

--- a/packages/svelte-materialify/src/components/Slider/Slider.svelte
+++ b/packages/svelte-materialify/src/components/Slider/Slider.svelte
@@ -49,7 +49,7 @@
 
   onMount(async () => {
     const { default: noUiSlider } = await import('./nouislider.min');
-    
+
     noUiSlider.cssClasses.tooltip = `tooltip ${thumbClass}`;
     noUiSlider.create(sliderElement, {
       cssPrefix: 's-slider__',


### PR DESCRIPTION
Closes #171

Based on these two resources, works in my Vite SPA application :

- https://github.com/TheComputerM/svelte-materialify/issues/171#issuecomment-802991037
- https://kit.svelte.dev/docs#troubleshooting-server-side-rendering