### PR TITLE
fix(types/select.d.ts): Value can be single value or array

### DIFF
--- a/packages/svelte-materialify/@types/Select.d.ts
+++ b/packages/svelte-materialify/@types/Select.d.ts
@@ -9,7 +9,7 @@ interface SelectProps {
    * Value of the select. 
    * If multiple is true, this will be an array; otherwise a single value.
    */
-  value?: (number[] | string[]) | number | string;
+  value?: number[] | string[] | number | string | null;
   /** List of items to select from. */
   items?: { name: string | number, value: string | number }[];
   /** Whether select is the `filled` material design variant. */

--- a/packages/svelte-materialify/@types/Select.d.ts
+++ b/packages/svelte-materialify/@types/Select.d.ts
@@ -5,8 +5,11 @@ interface SelectProps {
   class?: string;
   /** Whether select is opened. */
   active?: boolean;
-  /** Value of the select. */
-  value?: number[] | string[];
+  /**
+   * Value of the select. 
+   * If multiple is true, this will be an array; otherwise a single value.
+   */
+  value?: (number[] | string[]) | number | string;
   /** List of items to select from. */
   items?: { name: string | number, value: string | number }[];
   /** Whether select is the `filled` material design variant. */


### PR DESCRIPTION
When `multiple` prop is false, the value of a `<Select />` is a single value, not an array. Updated select.d.ts to reflect this.