### PR TITLE
Fix link for "Code of Conduct"

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For help and support questions, please join our [community discord](https://disc
 
 ## Contributing
 
-Thank you for taking the time to contribute, you should start by reading the [Code of Conduct]() and the [Contribution Guide](https://svelte-materialify.vercel.app/getting-started/contributing/).
+Thank you for taking the time to contribute, you should start by reading the [Code of Conduct](https://github.com/TheComputerM/svelte-materialify/blob/master/CODE_OF_CONDUCT.md) and the [Contribution Guide](https://svelte-materialify.vercel.app/getting-started/contributing/).
 
 ## Changelog
 


### PR DESCRIPTION
the link was empty. put the appropriate meaning, maybe I'm wrong.