### PR TITLE
fix(Types): Add MaterialAppMin type to declaration files

### DIFF
--- a/packages/svelte-materialify/@types/index.d.ts
+++ b/packages/svelte-materialify/@types/index.d.ts
@@ -31,6 +31,7 @@ export { default as ListGroup } from './ListGroup';
 export { default as ListItem } from './ListItem';
 export { default as ListItemGroup } from './ListItemGroup';
 export { default as MaterialApp } from './MaterialApp';
+export { default as MaterialAppMin } from './MaterialAppMin';
 export { default as Menu } from './Menu';
 export { default as NavigationDrawer } from './NavigationDrawer';
 export { default as Overlay } from './Overlay';


### PR DESCRIPTION
As seen in https://github.com/TheComputerM/svelte-materialify/issues/91#issuecomment-817824818 , the `MaterialAppMin` component is not shown to imports and yields an error in typescript codebases (or checked js codebases).

This should in theory fix it (didn't test it locally).

cc @Florian-Schoenherr