### PR TITLE
feat(definitions): Use relative imports consistently in d.ts files

### DIFF
--- a/packages/svelte-materialify/@types/Col.d.ts
+++ b/packages/svelte-materialify/@types/Col.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent } from 'svelte-materialify/@types/shared';
+import { SvelteComponent } from './shared';
 
 interface ColProps {
   /** cols adds class cols-<number> */

--- a/packages/svelte-materialify/@types/Container.d.ts
+++ b/packages/svelte-materialify/@types/Container.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent } from 'svelte-materialify/@types/shared';
+import { SvelteComponent } from './shared';
 
 interface ContainerProps {
   /** classes added to the container */

--- a/packages/svelte-materialify/@types/Divider.d.ts
+++ b/packages/svelte-materialify/@types/Divider.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent } from 'svelte-materialify/@types/shared';
+import { SvelteComponent } from './shared';
 
 interface DividerProps {
   /** inset moves divider 72px to the right */

--- a/packages/svelte-materialify/@types/Row.d.ts
+++ b/packages/svelte-materialify/@types/Row.d.ts
@@ -1,4 +1,4 @@
-import { SvelteComponent } from 'svelte-materialify/@types/shared';
+import { SvelteComponent } from './shared';
 
 interface RowProps {
   /** dense reduces standard gutter */

--- a/packages/svelte-materialify/@types/Snackbar.d.ts
+++ b/packages/svelte-materialify/@types/Snackbar.d.ts
@@ -1,5 +1,5 @@
-import { SvelteComponent } from 'svelte-materialify/@types/shared';
 import { TransitionConfig } from 'svelte/transition';
+import { SvelteComponent } from './shared';
 
 interface SnackbarProps {
   /** absolute sets the snackbar with position absolute otherwise it is fixed */


### PR DESCRIPTION
Only these five definition files imported SvelteComponent via 'svelte-materialify/@types/shared', while all other definitions used the './shared' relative path. This is a chore commit that brings consistency to the imports.