### PR TITLE
fix(types) Select, Breadcrumbs, ExpansionPanel slot type and VirtualList type

### DIFF
--- a/packages/svelte-materialify/@types/Breadcrumbs.d.ts
+++ b/packages/svelte-materialify/@types/Breadcrumbs.d.ts
@@ -19,6 +19,10 @@ interface BreadcrumbsProps {
   style?: string;
 }
 
-declare class Breadcrumbs extends SvelteComponent<BreadcrumbsProps> {}
+declare class Breadcrumbs extends SvelteComponent<BreadcrumbsProps> {
+  $$slot_def: {
+    item?: BreadcrumbItem,
+  };
+}
 
 export default Breadcrumbs;

--- a/packages/svelte-materialify/@types/ExpansionPanel.d.ts
+++ b/packages/svelte-materialify/@types/ExpansionPanel.d.ts
@@ -18,6 +18,10 @@ interface ExpansionPanelProps {
 
 }
 
-declare class ExpansionPanel extends SvelteComponent<ExpansionPanelProps> { }
+declare class ExpansionPanel extends SvelteComponent<ExpansionPanelProps> {
+  $$slot_def: {
+    active?: boolean,
+  };
+}
 
 export default ExpansionPanel;

--- a/packages/svelte-materialify/@types/Select.d.ts
+++ b/packages/svelte-materialify/@types/Select.d.ts
@@ -1,17 +1,19 @@
 import { SvelteComponent } from './shared';
 
+interface SelectItem { name: string | number, value: string | number }
+
 interface SelectProps {
   /** Classes to add to select wrapper. */
   class?: string;
   /** Whether select is opened. */
   active?: boolean;
   /**
-   * Value of the select. 
+   * Value of the select.
    * If multiple is true, this will be an array; otherwise a single value.
    */
   value?: number[] | string[] | number | string | null;
   /** List of items to select from. */
-  items?: { name: string | number, value: string | number }[];
+  items?: SelectItem[];
   /** Whether select is the `filled` material design variant. */
   filled?: boolean;
   /** Whether select is the `outlined` material design variant. */
@@ -43,6 +45,10 @@ interface SelectProps {
   format?: (value: string | number | string[] | number[]) => string | number;
 }
 
-declare class Select extends SvelteComponent<SelectProps> { }
+declare class Select extends SvelteComponent<SelectProps> {
+  $$slot_def: {
+    item?: SelectItem,
+  };
+}
 
 export default Select;

--- a/packages/svelte-materialify/@types/VirtualList.d.ts
+++ b/packages/svelte-materialify/@types/VirtualList.d.ts
@@ -1,0 +1,34 @@
+import { SvelteComponent } from './shared';
+
+interface VirtualListItem { text: string, subtitle?: string, items?: VirtualListItem[] }
+
+interface VirtualListProps {
+  /** Classes added to the footer. */
+  class?: string;
+
+  /** Whether the list group is opened */
+  active?: boolean;
+
+  /** List items */
+  items?: VirtualListItem[];
+
+  /** Classes to apply to the list items */
+  iteClasses?: string;
+
+  /** Depth of the list */
+  depth?: number;
+
+  /** Styles to add to the footer. */
+  style?: string;
+
+  /** Sets an offset on the element, takes the depth props as parameter */
+  offsetFunction?: Function;
+}
+
+declare class VirtualList extends SvelteComponent<VirtualListProps> {
+  $$slot_def: {
+    item?: VirtualListItem,
+  };
+}
+
+export default VirtualList;


### PR DESCRIPTION
I didnt add the VirtualList export in index.d.ts since it's supposed to be unavailable for now.
If I forgot any slot types, let me know !