### PR TITLE
chore: remove gumshoe

### DIFF
--- a/packages/docs/src/components/navigation/LeftNavigationDrawer.svelte
+++ b/packages/docs/src/components/navigation/LeftNavigationDrawer.svelte
@@ -14,10 +14,14 @@
   export let depth = 0;
   const offset = 1.5 ** depth * 54;
 
+  function equals(browserPath, navItemPath) {
+    return browserPath === navItemPath || `${browserPath}/` === navItemPath;
+  }
+
   function expand(parent) {
     const found = parent.some((child) => {
       if (child.items) return expand(child.items);
-      return $page.path === child.href;
+      return equals($page.path, child.href);
     });
     if (found) activeDepth = depth;
     return found;
@@ -44,7 +48,7 @@
       <svelte:self item={children} depth={depth + 1} />
     {:else}
       <a href={children.href} sapper:prefetch>
-        <ListItem active={children.href === $page.path}>{children.text}</ListItem>
+        <ListItem active={equals($page.path, children.href)}>{children.text}</ListItem>
       </a>
     {/if}
   {/each}

--- a/packages/docs/src/components/navigation/RightNavigationDrawer.svelte
+++ b/packages/docs/src/components/navigation/RightNavigationDrawer.svelte
@@ -1,18 +1,11 @@
 <script>
-  import Gumshoe from 'gumshoejs';
   import { onMount, tick } from 'svelte';
   import { markdown } from '@/util/stores';
+  import { hashURL } from '../../util/stores';
 
   let items = [];
   const depths = { H2: 'pl-3', H3: 'pl-6', H4: 'pl-8' };
-
   onMount(() => {
-    const spy = new Gumshoe('#toc a', {
-      events: false,
-      offset: 128,
-      navClass: 'active',
-    });
-
     async function refresh() {
       const basename = `${window.location.origin + window.location.pathname}#`;
       items = [];
@@ -27,7 +20,6 @@
         });
       items = items;
       await tick();
-      spy.setup();
     }
 
     const unsubscribe = markdown.subscribe((loaded) => {
@@ -35,7 +27,6 @@
     });
 
     return () => {
-      spy.destroy();
       unsubscribe();
     };
   });
@@ -64,7 +55,7 @@
 <h5 class="mb-3 mt-6">Contents</h5>
 <ul id="toc" class="pl-4">
   {#each items as item}
-    <li class="{item.class} pt-1 pb-1 text-body-2">
+    <li class="{item.class} pt-1 pb-1 text-body-2" class:active={item.href === $hashURL}>
       <a href={item.href}>{item.text}</a>
     </li>
   {/each}

--- a/packages/docs/src/routes/index.svelte
+++ b/packages/docs/src/routes/index.svelte
@@ -12,10 +12,10 @@
     Row,
     Col,
     Footer,
-    Alert
+    Alert,
   } from 'svelte-materialify/src';
   import Meta from '@/components/Meta.svelte';
-  import { mdiSpeedometer, mdiGithub, mdiPlus, mdiCheckBold, mdiTwitter } from '@mdi/js';
+  import { mdiSpeedometer, mdiGithub, mdiPlus, mdiTwitter } from '@mdi/js';
 </script>
 
 <style lang="scss">
@@ -100,17 +100,20 @@
     <h2 class="font-weight-bold">DISCLAMER</h2>
     <br />
     <p>
-      Svelte Materialify is soon to be deprecated is favour of <a href="https://github.com/svelterialjs/svelterial">svelterialjs</a>. 
-      My exams are still going on as they were postponed due to the increasing number of CoVID cases in 
-      my country.
+      Svelte Materialify is soon to be deprecated is favour of <a
+        href="https://github.com/svelterialjs/svelterial">svelterialjs</a
+      >. My exams are still going on as they were postponed due to the increasing number
+      of CoVID cases in my country.
     </p>
   </Alert>
-  
+
   <p>
-    I would like to apologize to <a href="https://github.com/hperrin/svelte-material-ui">Svelte Material UI</a> for
-    posting wrong and outdated information in the comparision table. SMUI 4 is an extremely good alternative to svelte materialify
-    while the rewrite <a href="https://github.com/svelterialjs/svelterial">Svelterial</a> is still in development.
-  </p>  
+    I would like to apologize to <a href="https://github.com/hperrin/svelte-material-ui"
+      >Svelte Material UI</a>
+    for posting wrong and outdated information in the comparision table. SMUI 4 is an
+    extremely good alternative to svelte materialify while the rewrite
+    <a href="https://github.com/svelterialjs/svelterial">Svelterial</a> is still in development.
+  </p>
 </Container>
 
 <Footer class="theme--dark">

--- a/packages/docs/src/util/stores.js
+++ b/packages/docs/src/util/stores.js
@@ -7,3 +7,7 @@ export { theme };
 const markdown = writable(false);
 
 export { markdown };
+
+const hashURL = writable(process.browser ? window.location.href : '');
+
+export { hashURL };


### PR DESCRIPTION
Closes #115. I built my own little scrollspy, only the back-button is not the same, it actually ignores the hash-values. I think that's good, because it means the hash can be set on scroll. For the end of the lifetime of this lib, it should be enough.