### PR TITLE
css overrides - makes the pa-* and ma-* overridable.

### DIFF
--- a/packages/svelte-materialify/src/styles/generic/_display.scss
+++ b/packages/svelte-materialify/src/styles/generic/_display.scss
@@ -4,6 +4,9 @@
   .d-#{$display} {
     display: unquote($display);
   }
+}
+
+@each $display in ('none', 'inline', 'inline-block', 'block', 'flex', 'inline-flex') {
   @include create_breakpoints() using ($screen_size) {
     .d-#{$screen_size}-#{$display} {
       display: unquote($display);

--- a/packages/svelte-materialify/src/styles/generic/_spacing.scss
+++ b/packages/svelte-materialify/src/styles/generic/_spacing.scss
@@ -19,8 +19,8 @@
 @for $i from 0 through 16 {
   @each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
     @each $type,
-      $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
-      
+      $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom')
+    {
       @include create_breakpoints() using ($screen_size) {
         .#{$mORp}#{$type}-#{$screen_size}-#{$i} {
           #{$marginORpadding}#{$suffix}: $spacer * $i !important;
@@ -35,7 +35,8 @@
 
 @each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
   @each $type,
-    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
+    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom')
+  {
     .#{$mORp}#{$type}-auto {
       #{$marginORpadding}#{$suffix}: auto !important;
     }
@@ -44,7 +45,8 @@
 
 @each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
   @each $type,
-    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
+    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom')
+  {
     @include create_breakpoints() using ($screen_size) {
       .#{$mORp}#{$type}-#{$screen_size}-auto {
         #{$marginORpadding}#{$suffix}: auto !important;

--- a/packages/svelte-materialify/src/styles/generic/_spacing.scss
+++ b/packages/svelte-materialify/src/styles/generic/_spacing.scss
@@ -12,7 +12,15 @@
       .#{$mORp}#{$type}-n#{$i} {
         #{$marginORpadding}#{$suffix}: $spacer * -$i !important;
       }
+    }
+  }
+}
 
+@for $i from 0 through 16 {
+  @each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
+    @each $type,
+      $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
+      
       @include create_breakpoints() using ($screen_size) {
         .#{$mORp}#{$type}-#{$screen_size}-#{$i} {
           #{$marginORpadding}#{$suffix}: $spacer * $i !important;
@@ -27,12 +35,16 @@
 
 @each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
   @each $type,
-    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom')
-  {
+    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
     .#{$mORp}#{$type}-auto {
       #{$marginORpadding}#{$suffix}: auto !important;
     }
+  }
+}
 
+@each $mORp, $marginORpadding in ('m': 'margin', 'p': 'padding') {
+  @each $type,
+    $suffix in ('a': '', 'l': '-left', 'r': '-right', 't': '-top', 'b': '-bottom'){
     @include create_breakpoints() using ($screen_size) {
       .#{$mORp}#{$type}-#{$screen_size}-auto {
         #{$marginORpadding}#{$suffix}: auto !important;

--- a/packages/svelte-materialify/src/styles/generic/_typography.scss
+++ b/packages/svelte-materialify/src/styles/generic/_typography.scss
@@ -6,6 +6,9 @@
   .text-#{$align} {
     text-align: #{$align};
   }
+}
+
+@each $align in ('left', 'center', 'right') {
   @include create_breakpoints() using ($screen_size) {
     .text-#{$screen_size}-#{$align} {
       text-align: #{$align};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,6 +1307,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fortawesome/fontawesome-common-types@^0.2.35":
+  version "0.2.35"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz#01dd3d054da07a00b764d78748df20daf2b317e9"
+  integrity sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==
+
+"@fortawesome/free-solid-svg-icons@^5.15.2":
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz#52eebe354f60dc77e0bde934ffc5c75ffd04f9d8"
+  integrity sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.35"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
right now the order of generation in the _spacing.scss file generates all 0,1,2,3...etc classes.
By changing the iteration order, pa-* and ma-* are generated first, so they can be overridden by following classes and be able to achive a  pt-4 pl-4 pr-4 pt-8 by simply writing pa-4 pt-8 