### PR TITLE
fix(ListGroup): offset not applied when toggling off and on quickly

### DIFF
--- a/packages/svelte-materialify/src/components/List/ListGroup.svelte
+++ b/packages/svelte-materialify/src/components/List/ListGroup.svelte
@@ -21,6 +21,9 @@
 
   function toggle() {
     active = !active;
+    const tempOffSet = offset;
+    offset += 0.0001;
+    offset = tempOffSet;
   }
 
   if (eager) {


### PR DESCRIPTION
Closes #75 
To get a gist of the issue at hand, if you go at https://svelte-materialify.vercel.app/components/lists/#nested and toggle on the nested ListGroup element, everything looks fine. However, if you now double click the `Actions` element (basically closing and opening the nested ListGroup element), you will see that the offset is not applied anymore.

I believe this is due to a weird interaction with Svelte where the transition is applied the the `use:Style` directive doesn't get applied when the element isn't fully removed yet (due to the transition). I tested it locally and couldn't find a proper fix.

However, since the use directive of the `Style` function is updateable, if you reactively update the `offset` variable, the use directive gets reapplied every time you toggle the ListGroup, which fixes this issue.

I do not exactly like this fix, as it does bring more overhead for even regular toggles (which didn't have this issue) and therefore runs more code than before, but the lack of offset on double click is, IMO, a more annoying issue than trying to fix Svelte currently. Besides, once Svelterial comes out, maybe this issue won't be there anymore - but this should be addressed for Svelte-Materialify as svelterial isn't out yet.