### PR TITLE
fix(Tooltip.svelte): don't destroy tip node, let svelte do it

### DIFF
--- a/packages/svelte-materialify/src/components/Tooltip/Tooltip.svelte
+++ b/packages/svelte-materialify/src/components/Tooltip/Tooltip.svelte
@@ -115,8 +115,6 @@
   onMount(() => {
     document.body.appendChild(tooltip);
     updateTooltipPosition();
-
-    return () => document.body.removeChild(tooltip);
   });
 </script>
 

--- a/packages/svelte-materialify/tests/Tooltip/can_destroy.js
+++ b/packages/svelte-materialify/tests/Tooltip/can_destroy.js
@@ -1,0 +1,16 @@
+import { render, cleanup } from '@testing-library/svelte';
+import Tooltip from '@s/components/Tooltip';
+import html from 'svelte-htm';
+
+describe('Tooltip', () => {
+  test('can destroy', () => {
+    const noop = () => {};
+    Object.defineProperty(window, 'scrollTo', { value: noop, writable: true });
+    const { getByText } = render(
+      html`<${Tooltip} top><span>activator</span><span slot="tip">tip</span><//>`,
+    );
+    const tip = getByText('tip');
+    cleanup();
+    expect(tip).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
When destroying a Tooltip, the tooltip node was removed twice: once by svelte and once by the component.

This pull requests removes the `removeChild` call in the component and adds a test, that checks if the Tooltip component can be destroyed without an error and the tooltip node gets removed correctly.