### PR TITLE
fix: remove role from `Divider`

### DIFF
--- a/packages/svelte-materialify/src/components/Divider/Divider.svelte
+++ b/packages/svelte-materialify/src/components/Divider/Divider.svelte
@@ -11,7 +11,6 @@
 
 <hr
   class="s-divider {klass}"
-  role="separator"
   aria-orientation={vertical ? 'vertical' : 'horizontal'}
   class:inset
   class:vertical


### PR DESCRIPTION
Hey, thanks for the library!
While using it, I noticed svelte throws an a11y warning while compiling. The role attribute seems to be unnecessary, so I removed it as recommended.

Hope your exams are going good! Even tho the lib deprecates soon, I think this should go in a potential last release.

![Bildschirmfoto 2022-05-01 um 15 03 45](https://user-images.githubusercontent.com/6831124/166147195-a5dca703-339a-47a3-b723-e9f20d49b8d4.png)
